### PR TITLE
Fix missing #endif

### DIFF
--- a/Sources/Engine/Engine.cpp
+++ b/Sources/Engine/Engine.cpp
@@ -224,6 +224,7 @@ static void DetectCPU(void)
   sys_iCPUMHz = INDEX(_pTimer->tm_llCPUSpeedHZ/1E6);
 
   if( !bMMX) FatalError( TRANS("MMX support required but not present!"));
+#endif
 }
 
 static void DetectCPUWrapper(void)


### PR DESCRIPTION
On Linux the compiler was complaining about a missing #endif. I don't know if this is the right place, but now it compiles, at least.
